### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,2 +1,5 @@
+.. image:: https://badge.waffle.io/usebenchmark/benchmark-insights.png?label=ready&title=Ready 
+ :target: https://waffle.io/usebenchmark/benchmark-insights
+ :alt: 'Stories in Ready'
 # benchmark-insights
 Benchmark's insight engine


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/usebenchmark/benchmark-insights

This was requested by a real person (user kennethkoontz) on waffle.io, we're not trying to spam you.
